### PR TITLE
Update pack format for Minecraft 1.21.5

### DIFF
--- a/Minecraft Tickless Datapack/pack.mcmeta
+++ b/Minecraft Tickless Datapack/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
-    "pack_format": 81,
+    "pack_format": 48,
     "description": "Minecraft: Tickless - это датапак для Tickless челленджа в Minecraft. Правила можно узнать на официальном Discord-сервере или просто играть в своё удовольствие)"
   }
 }


### PR DESCRIPTION
## Summary
- set `pack_format` to 48 for Minecraft 1.21.5 datapack

## Testing
- `python -m pytest`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c571f30c833090cd357aa79503d9