### PR TITLE
Namespace item types in loot tables

### DIFF
--- a/Minecraft Tickless Datapack/data/tickless/loot_tables/inject/blaze_bonus.json
+++ b/Minecraft Tickless Datapack/data/tickless/loot_tables/inject/blaze_bonus.json
@@ -4,7 +4,7 @@
       "rolls": 1,
       "entries": [
         {
-          "type": "item",
+          "type": "minecraft:item",
           "name": "minecraft:blaze_rod",
           "functions": [
             {

--- a/Minecraft Tickless Datapack/data/tickless/loot_tables/inject/trial_bonus.json
+++ b/Minecraft Tickless Datapack/data/tickless/loot_tables/inject/trial_bonus.json
@@ -4,7 +4,7 @@
       "rolls": 1,
       "entries": [
         {
-          "type": "item",
+          "type": "minecraft:item",
           "name": "minecraft:breeze_rod"
         }
       ],
@@ -19,7 +19,7 @@
       "rolls": 1,
       "entries": [
         {
-          "type": "item",
+          "type": "minecraft:item",
           "name": "minecraft:heavy_core"
         }
       ],


### PR DESCRIPTION
## Summary
- qualify loot entries with `minecraft:item` in blaze and trial bonus tables

## Testing
- `jq '.' 'Minecraft Tickless Datapack/data/tickless/loot_tables/inject/blaze_bonus.json'`
- `jq '.' 'Minecraft Tickless Datapack/data/tickless/loot_tables/inject/trial_bonus.json'`


------
https://chatgpt.com/codex/tasks/task_e_68a4c57791fc83309b027d369141d37b